### PR TITLE
delete  css class  container from   body .

### DIFF
--- a/website_rtl/views/templates.xml
+++ b/website_rtl/views/templates.xml
@@ -12,7 +12,7 @@
                 <t t-set="body_classname" t-value="request.context.get('lang_dir', 'ltr')"/>
             </xpath>
             <xpath expr="//html/body" position="attributes">
-                <attribute name="t-att-class">request.context.get('lang_dir', 'ltr') + ' container'</attribute>
+                <attribute name="t-att-class">request.context.get('lang_dir', 'ltr')</attribute>
             </xpath>
             
             


### PR DESCRIPTION
css class  container in odoo  : 
@media (min-width: 1200px)
.container {
    width: 1170px;
 }

so the site does not displayed in full page ( <body class="rtl container">) so delete this class from body .
